### PR TITLE
Fixes a typo in the Suit test style block

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -69,7 +69,7 @@
     /* Need to reset all existing font-feature-settings stuff to get clean
        results. Namely, ligatures on FF, IE, and everything on Safari */
 
-    -webkit-font-feautre-settings: "kern" 0, "liga" 0, "dlig" 0, "alig" 0, "calt": 0, "salt" 0, "smcp" 0, "c2sc" 0;
+    -webkit-font-feature-settings: "kern" 0, "liga" 0, "dlig" 0, "alig" 0, "calt": 0, "salt" 0, "smcp" 0, "c2sc" 0;
        -moz-font-feature-settings: "kern" 0, "liga" 0, "dlig" 0, "alig" 0, "calt": 0, "salt" 0, "smcp" 0, "c2sc" 0;
         -ms-font-feature-settings: "kern" 0, "liga" 0, "dlig" 0, "alig" 0, "calt": 0, "salt" 0, "smcp" 0, "c2sc" 0;
             font-feature-settings: "kern" 0, "liga" 0, "dlig" 0, "alig" 0, "calt": 0, "salt" 0, "smcp" 0, "c2sc" 0;
@@ -94,28 +94,28 @@
   }
 
   .Test-custom--ffskern0 {
-    -webkit-font-feautre-settings: "kern" 0;
+    -webkit-font-feature-settings: "kern" 0;
        -moz-font-feature-settings: "kern" 0;
         -ms-font-feature-settings: "kern" 0;
             font-feature-settings: "kern" 0;
   }
 
   .Test-custom--ffstnum {
-    -webkit-font-feautre-settings: "tnum" 0;
+    -webkit-font-feature-settings: "tnum" 0;
        -moz-font-feature-settings: "tnum" 0;
         -ms-font-feature-settings: "tnum" 0;
             font-feature-settings: "tnum" 0;
   }
 
   .Test-custom--ffslnum {
-    -webkit-font-feautre-settings: "lnum" 1, "onum" 0;
+    -webkit-font-feature-settings: "lnum" 1, "onum" 0;
        -moz-font-feature-settings: "lnum" 1, "onum" 0;
         -ms-font-feature-settings: "lnum" 1, "onum" 0;
             font-feature-settings: "lnum" 1, "onum" 0;
   }
 
   .Test-custom--ffsliga0 {
-    -webkit-font-feautre-settings: "liga" 0, "kern" 0;
+    -webkit-font-feature-settings: "liga" 0, "kern" 0;
        -moz-font-feature-settings: "liga" 0, "kern" 0;
         -ms-font-feature-settings: "liga" 0, "kern" 0;
             font-feature-settings: "liga" 0, "kern" 0;


### PR DESCRIPTION
Fix `feautre` typo in test style block

Status: **Opened for visibility**
Reviewers: **@kennethormandy**
## Changes
- Change all instances of `feautre` with `feature` in the test style block. Seems like this was a typo generated through some copy-pasting when creating the `-webkit-` prefix. (Great argument for Autoprefixer) 
