### PR TITLE
Add `main` and `style` properties to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "normalize-opentype.css",
   "version": "0.2.4",
   "description": "Adds OpenType features—ligatures, kerning, and more—to Normalize.css.",
+  "main": "normalize-opentype.css",
+  "style": "normalize-opentype.css",
   "homepage": "http://kennethormandy.com/journal/normalize-opentype-css",
   "author": "Kenneth Ormandy <hello@kennethormandy.com>",
   "license": "MIT",


### PR DESCRIPTION
This is helpful if you want to import npm packages (like this one) in CSS/SASS/Less without having to specify the full path to the `node_modules` folder (http://stackoverflow.com/questions/32037150/style-field-in-package-json).

The [sass-module-importer](https://github.com/lucasmotta/sass-module-importer) and many other modules are also checking the `package.json` file for a `main` or `style` property.
